### PR TITLE
Store `StudyMetadata` in GridFS (GSI-1919)

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -3,6 +3,8 @@ kafka_servers: ["kafka:9092"]
 mongo_dsn: mongodb://localhost:27017
 db_name: rts
 mongo_timeout: 300
+db_version_collection: rtsDbVersions
+migration_wait_sec: 10
 artifact_topic: artifacts
 sheet_names:
   analyses: Analysis

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rts"
-version = "2.0.1"
+version = "2.1.0"
 description = "Reverse Transpiler Service - A service running a REST API that serves accessioned metadata files by study ID"
 dependencies = [
     "typer >= 0.19",

--- a/.readme_generation/readme_template.md
+++ b/.readme_generation/readme_template.md
@@ -13,7 +13,7 @@ $description
 
 We recommend using the provided Docker container.
 
-A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/$name):
+A pre-built version is available on [Docker Hub](https://hub.docker.com/repository/docker/ghga/$name):
 ```bash
 docker pull ghga/$name:$version
 ```
@@ -24,11 +24,11 @@ Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 docker build -t ghga/$name:$version .
 ```
 
-For production-ready deployment, we recommend using Kubernetes, however,
-for simple use cases, you could execute the service using docker
+For production-ready deployment, we recommend using Kubernetes.
+However for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
-# The entrypoint is preconfigured:
+# The entrypoint is pre-configured:
 docker run -p 8080:8080 ghga/$name:$version --help
 ```
 
@@ -50,18 +50,18 @@ $config_description
 
 ### Usage:
 
-A template YAML for configuring the service can be found at
+A template YAML file for configuring the service can be found at
 [`./example_config.yaml`](./example_config.yaml).
 Please adapt it, rename it to `.$shortname.yaml`, and place it in one of the following locations:
 - in the current working directory where you execute the service (on Linux: `./.$shortname.yaml`)
 - in your home directory (on Linux: `~/.$shortname.yaml`)
 
-The config yaml will be automatically parsed by the service.
+The config YAML file will be automatically parsed by the service.
 
 **Important: If you are using containers, the locations refer to paths within the container.**
 
 All parameters mentioned in the [`./example_config.yaml`](./example_config.yaml)
-could also be set using environment variables or file secrets.
+can also be set using environment variables or file secrets.
 
 For naming the environment variables, just prefix the parameter name with `${shortname}_`,
 e.g. for the `host` set an environment variable named `${shortname}_host`
@@ -95,12 +95,12 @@ This will give you a full-fledged, pre-configured development environment includ
 - a pre-configured debugger
 - automatic license-header insertion
 
-Moreover, inside the devcontainer, a command `dev_install` is available for convenience.
+Inside the devcontainer, a command `dev_install` is available for convenience.
 It installs the service with all development dependencies, and it installs pre-commit.
 
 The installation is performed automatically when you build the devcontainer. However,
 if you update dependencies in the [`./pyproject.toml`](./pyproject.toml) or the
-[`lock/requirements-dev.txt`](./lock/requirements-dev.txt), please run it again.
+[`lock/requirements-dev.txt`](./lock/requirements-dev.txt), run it again.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here you should provide a short summary of the purpose of this microservice.
 
 We recommend using the provided Docker container.
 
-A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/reverse-transpiler-service):
+A pre-built version is available on [Docker Hub](https://hub.docker.com/repository/docker/ghga/reverse-transpiler-service):
 ```bash
 docker pull ghga/reverse-transpiler-service:2.0.1
 ```
@@ -27,11 +27,11 @@ Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 docker build -t ghga/reverse-transpiler-service:2.0.1 .
 ```
 
-For production-ready deployment, we recommend using Kubernetes, however,
-for simple use cases, you could execute the service using docker
+For production-ready deployment, we recommend using Kubernetes.
+However for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
-# The entrypoint is preconfigured:
+# The entrypoint is pre-configured:
 docker run -p 8080:8080 ghga/reverse-transpiler-service:2.0.1 --help
 ```
 
@@ -51,318 +51,265 @@ rts --help
 The service requires the following configuration parameters:
 - <a id="properties/artifact_topic"></a>**`artifact_topic`** *(string, required)*: Name of the event topic containing artifact events.
 
-
   Examples:
-
   ```json
   "artifacts"
   ```
 
-
 - <a id="properties/mongo_dsn"></a>**`mongo_dsn`** *(string, format: multi-host-uri, required)*: MongoDB connection string. Might include credentials. For more information see: https://naiveskill.com/mongodb-connection-string/. Length must be at least 1.
 
-
   Examples:
-
   ```json
   "mongodb://localhost:27017"
   ```
 
-
 - <a id="properties/db_name"></a>**`db_name`** *(string, required)*: Name of the database located on the MongoDB server.
 
-
   Examples:
-
   ```json
   "my-database"
   ```
 
-
 - <a id="properties/mongo_timeout"></a>**`mongo_timeout`**: Timeout in seconds for API calls to MongoDB. The timeout applies to all steps needed to complete the operation, including server selection, connection checkout, serialization, and server-side execution. When the timeout expires, PyMongo raises a timeout exception. If set to None, the operation will not time out (default MongoDB behavior). Default: `null`.
-
   - **Any of**
-
     - <a id="properties/mongo_timeout/anyOf/0"></a>*integer*: Exclusive minimum: `0`.
-
     - <a id="properties/mongo_timeout/anyOf/1"></a>*null*
 
-
   Examples:
-
   ```json
   300
   ```
-
 
   ```json
   600
   ```
 
-
   ```json
   null
   ```
 
-
-- <a id="properties/service_name"></a>**`service_name`** *(string)*: Short name of this service. Default: `"rts"`.
-
-- <a id="properties/service_instance_id"></a>**`service_instance_id`** *(string, required)*: A string that uniquely identifies this instance across all instances of this service. This is included in log messages.
-
+- <a id="properties/db_version_collection"></a>**`db_version_collection`** *(string, required)*: The name of the collection containing DB version information for this service.
 
   Examples:
+  ```json
+  "ifrsDbVersions"
+  ```
 
+- <a id="properties/migration_wait_sec"></a>**`migration_wait_sec`** *(integer, required)*: The number of seconds to wait before checking the DB version again.
+
+  Examples:
+  ```json
+  5
+  ```
+
+  ```json
+  30
+  ```
+
+  ```json
+  180
+  ```
+
+- <a id="properties/migration_max_wait_sec"></a>**`migration_max_wait_sec`**: The maximum number of seconds to wait for migrations to complete before raising an error. Default: `null`.
+  - **Any of**
+    - <a id="properties/migration_max_wait_sec/anyOf/0"></a>*integer*
+    - <a id="properties/migration_max_wait_sec/anyOf/1"></a>*null*
+
+  Examples:
+  ```json
+  null
+  ```
+
+  ```json
+  300
+  ```
+
+  ```json
+  600
+  ```
+
+  ```json
+  3600
+  ```
+
+- <a id="properties/service_name"></a>**`service_name`** *(string)*: Short name of this service. Default: `"rts"`.
+- <a id="properties/service_instance_id"></a>**`service_instance_id`** *(string, required)*: A string that uniquely identifies this instance across all instances of this service. This is included in log messages.
+
+  Examples:
   ```json
   "germany-bw-instance-001"
   ```
 
-
 - <a id="properties/kafka_servers"></a>**`kafka_servers`** *(array, required)*: A list of connection strings to connect to Kafka bootstrap servers.
-
   - <a id="properties/kafka_servers/items"></a>**Items** *(string)*
 
-
   Examples:
-
   ```json
   [
       "localhost:9092"
   ]
   ```
 
-
 - <a id="properties/kafka_security_protocol"></a>**`kafka_security_protocol`** *(string)*: Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL. Must be one of: "PLAINTEXT" or "SSL". Default: `"PLAINTEXT"`.
-
 - <a id="properties/kafka_ssl_cafile"></a>**`kafka_ssl_cafile`** *(string)*: Certificate Authority file path containing certificates used to sign broker certificates. If a CA is not specified, the default system CA will be used if found by OpenSSL. Default: `""`.
-
 - <a id="properties/kafka_ssl_certfile"></a>**`kafka_ssl_certfile`** *(string)*: Optional filename of client certificate, as well as any CA certificates needed to establish the certificate's authenticity. Default: `""`.
-
 - <a id="properties/kafka_ssl_keyfile"></a>**`kafka_ssl_keyfile`** *(string)*: Optional filename containing the client private key. Default: `""`.
-
 - <a id="properties/kafka_ssl_password"></a>**`kafka_ssl_password`** *(string, format: password, write-only)*: Optional password to be used for the client private key. Default: `""`.
-
 - <a id="properties/generate_correlation_id"></a>**`generate_correlation_id`** *(boolean)*: A flag, which, if False, will result in an error when inbound requests don't possess a correlation ID. If True, requests without a correlation ID will be assigned a newly generated ID in the correlation ID middleware function. Default: `true`.
 
-
   Examples:
-
   ```json
   true
   ```
-
 
   ```json
   false
   ```
 
-
 - <a id="properties/kafka_max_message_size"></a>**`kafka_max_message_size`** *(integer)*: The largest message size that can be transmitted, in bytes, before compression. Only services that have a need to send/receive larger messages should set this. When used alongside compression, this value can be set to something greater than the broker's `message.max.bytes` field, which effectively concerns the compressed message size. Exclusive minimum: `0`. Default: `1048576`.
 
-
   Examples:
-
   ```json
   1048576
   ```
-
 
   ```json
   16777216
   ```
 
-
 - <a id="properties/kafka_compression_type"></a>**`kafka_compression_type`**: The compression type used for messages. Valid values are: None, gzip, snappy, lz4, and zstd. If None, no compression is applied. This setting is only relevant for the producer and has no effect on the consumer. If set to a value, the producer will compress messages before sending them to the Kafka broker. If unsure, zstd provides a good balance between speed and compression ratio. Default: `null`.
-
   - **Any of**
-
     - <a id="properties/kafka_compression_type/anyOf/0"></a>*string*: Must be one of: "gzip", "snappy", "lz4", or "zstd".
-
     - <a id="properties/kafka_compression_type/anyOf/1"></a>*null*
 
-
   Examples:
-
   ```json
   null
   ```
-
 
   ```json
   "gzip"
   ```
 
-
   ```json
   "snappy"
   ```
-
 
   ```json
   "lz4"
   ```
 
-
   ```json
   "zstd"
   ```
 
-
 - <a id="properties/kafka_max_retries"></a>**`kafka_max_retries`** *(integer)*: The maximum number of times to immediately retry consuming an event upon failure. Works independently of the dead letter queue. Minimum: `0`. Default: `0`.
 
-
   Examples:
-
   ```json
   0
   ```
-
 
   ```json
   1
   ```
 
-
   ```json
   2
   ```
-
 
   ```json
   3
   ```
 
-
   ```json
   5
   ```
 
-
 - <a id="properties/kafka_enable_dlq"></a>**`kafka_enable_dlq`** *(boolean)*: A flag to toggle the dead letter queue. If set to False, the service will crash upon exhausting retries instead of publishing events to the DLQ. If set to True, the service will publish events to the DLQ topic after exhausting all retries. Default: `false`.
 
-
   Examples:
-
   ```json
   true
   ```
-
 
   ```json
   false
   ```
 
-
 - <a id="properties/kafka_dlq_topic"></a>**`kafka_dlq_topic`** *(string)*: The name of the topic used to resolve error-causing events. Default: `"dlq"`.
 
-
   Examples:
-
   ```json
   "dlq"
   ```
 
-
 - <a id="properties/kafka_retry_backoff"></a>**`kafka_retry_backoff`** *(integer)*: The number of seconds to wait before retrying a failed event. The backoff time is doubled for each retry attempt. Minimum: `0`. Default: `0`.
 
-
   Examples:
-
   ```json
   0
   ```
-
 
   ```json
   1
   ```
 
-
   ```json
   2
   ```
-
 
   ```json
   3
   ```
 
-
   ```json
   5
   ```
 
-
 - <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", or "TRACE". Default: `"INFO"`.
-
 - <a id="properties/log_format"></a>**`log_format`**: If set, will replace JSON formatting with the specified string format. If not set, has no effect. In addition to the standard attributes, the following can also be specified: timestamp, service, instance, level, correlation_id, and details. Default: `null`.
-
   - **Any of**
-
     - <a id="properties/log_format/anyOf/0"></a>*string*
-
     - <a id="properties/log_format/anyOf/1"></a>*null*
 
-
   Examples:
-
   ```json
   "%(timestamp)s - %(service)s - %(level)s - %(message)s"
   ```
-
 
   ```json
   "%(asctime)s - Severity: %(levelno)s - %(msg)s"
   ```
 
-
 - <a id="properties/log_traceback"></a>**`log_traceback`** *(boolean)*: Whether to include exception tracebacks in log messages. Default: `true`.
-
 - <a id="properties/host"></a>**`host`** *(string)*: IP of the host. Default: `"127.0.0.1"`.
-
 - <a id="properties/port"></a>**`port`** *(integer)*: Port to expose the server on the specified host. Default: `8080`.
-
 - <a id="properties/auto_reload"></a>**`auto_reload`** *(boolean)*: A development feature. Set to `True` to automatically reload the server upon code changes. Default: `false`.
-
 - <a id="properties/workers"></a>**`workers`** *(integer)*: Number of workers processes to run. Default: `1`.
-
 - <a id="properties/api_root_path"></a>**`api_root_path`** *(string)*: Root path at which the API is reachable. This is relative to the specified host and port. Default: `""`.
-
 - <a id="properties/openapi_url"></a>**`openapi_url`** *(string)*: Path to get the openapi specification in JSON format. This is relative to the specified host and port. Default: `"/openapi.json"`.
-
 - <a id="properties/docs_url"></a>**`docs_url`** *(string)*: Path to host the swagger documentation. This is relative to the specified host and port. Default: `"/docs"`.
-
 - <a id="properties/cors_allowed_origins"></a>**`cors_allowed_origins`**: A list of origins that should be permitted to make cross-origin requests. By default, cross-origin requests are not allowed. You can use ['*'] to allow any origin. Default: `null`.
-
   - **Any of**
-
     - <a id="properties/cors_allowed_origins/anyOf/0"></a>*array*
-
       - <a id="properties/cors_allowed_origins/anyOf/0/items"></a>**Items** *(string)*
-
     - <a id="properties/cors_allowed_origins/anyOf/1"></a>*null*
 
-
   Examples:
-
   ```json
   [
       "https://example.org",
       "https://www.example.org"
   ]
   ```
-
 
 - <a id="properties/cors_allow_credentials"></a>**`cors_allow_credentials`**: Indicate that cookies should be supported for cross-origin requests. Defaults to False. Also, cors_allowed_origins cannot be set to ['*'] for credentials to be allowed. The origins must be explicitly specified. Default: `null`.
-
   - **Any of**
-
     - <a id="properties/cors_allow_credentials/anyOf/0"></a>*boolean*
-
     - <a id="properties/cors_allow_credentials/anyOf/1"></a>*null*
 
-
   Examples:
-
   ```json
   [
       "https://example.org",
@@ -370,70 +317,45 @@ The service requires the following configuration parameters:
   ]
   ```
 
-
 - <a id="properties/cors_allowed_methods"></a>**`cors_allowed_methods`**: A list of HTTP methods that should be allowed for cross-origin requests. Defaults to ['GET']. You can use ['*'] to allow all standard methods. Default: `null`.
-
   - **Any of**
-
     - <a id="properties/cors_allowed_methods/anyOf/0"></a>*array*
-
       - <a id="properties/cors_allowed_methods/anyOf/0/items"></a>**Items** *(string)*
-
     - <a id="properties/cors_allowed_methods/anyOf/1"></a>*null*
 
-
   Examples:
-
   ```json
   [
       "*"
   ]
   ```
 
-
 - <a id="properties/cors_allowed_headers"></a>**`cors_allowed_headers`**: A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all request headers. The Accept, Accept-Language, Content-Language, Content-Type and some are always allowed for CORS requests. Default: `null`.
-
   - **Any of**
-
     - <a id="properties/cors_allowed_headers/anyOf/0"></a>*array*
-
       - <a id="properties/cors_allowed_headers/anyOf/0/items"></a>**Items** *(string)*
-
     - <a id="properties/cors_allowed_headers/anyOf/1"></a>*null*
 
-
   Examples:
-
   ```json
   []
   ```
-
 
 - <a id="properties/cors_exposed_headers"></a>**`cors_exposed_headers`**: A list of HTTP response headers that should be exposed for cross-origin responses. Defaults to []. Note that you can NOT use ['*'] to expose all response headers. The Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified and Pragma headers are always exposed for CORS responses. Default: `null`.
-
   - **Any of**
-
     - <a id="properties/cors_exposed_headers/anyOf/0"></a>*array*
-
       - <a id="properties/cors_exposed_headers/anyOf/0/items"></a>**Items** *(string)*
-
     - <a id="properties/cors_exposed_headers/anyOf/1"></a>*null*
 
-
   Examples:
-
   ```json
   []
   ```
 
-
 - <a id="properties/sheet_names"></a>**`sheet_names`** *(object, required)*: Mapping of worksheet names to display names in the workbook. Can contain additional properties.
-
   - <a id="properties/sheet_names/additionalProperties"></a>**Additional properties** *(string)*: Length must be between 1 and 31 (inclusive).
 
-
   Examples:
-
   ```json
   {
       "analyses": "Analysis",
@@ -441,22 +363,20 @@ The service requires the following configuration parameters:
   }
   ```
 
-
-
 ### Usage:
 
-A template YAML for configuring the service can be found at
+A template YAML file for configuring the service can be found at
 [`./example_config.yaml`](./example_config.yaml).
 Please adapt it, rename it to `.rts.yaml`, and place it in one of the following locations:
 - in the current working directory where you execute the service (on Linux: `./.rts.yaml`)
 - in your home directory (on Linux: `~/.rts.yaml`)
 
-The config yaml will be automatically parsed by the service.
+The config YAML file will be automatically parsed by the service.
 
 **Important: If you are using containers, the locations refer to paths within the container.**
 
 All parameters mentioned in the [`./example_config.yaml`](./example_config.yaml)
-could also be set using environment variables or file secrets.
+can also be set using environment variables or file secrets.
 
 For naming the environment variables, just prefix the parameter name with `rts_`,
 e.g. for the `host` set an environment variable named `rts_host`
@@ -498,12 +418,12 @@ This will give you a full-fledged, pre-configured development environment includ
 - a pre-configured debugger
 - automatic license-header insertion
 
-Moreover, inside the devcontainer, a command `dev_install` is available for convenience.
+Inside the devcontainer, a command `dev_install` is available for convenience.
 It installs the service with all development dependencies, and it installs pre-commit.
 
 The installation is performed automatically when you build the devcontainer. However,
 if you update dependencies in the [`./pyproject.toml`](./pyproject.toml) or the
-[`lock/requirements-dev.txt`](./lock/requirements-dev.txt), please run it again.
+[`lock/requirements-dev.txt`](./lock/requirements-dev.txt), run it again.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available on [Docker Hub](https://hub.docker.com/repository/docker/ghga/reverse-transpiler-service):
 ```bash
-docker pull ghga/reverse-transpiler-service:2.0.1
+docker pull ghga/reverse-transpiler-service:2.1.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/reverse-transpiler-service:2.0.1 .
+docker build -t ghga/reverse-transpiler-service:2.1.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes.
@@ -32,7 +32,7 @@ However for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is pre-configured:
-docker run -p 8080:8080 ghga/reverse-transpiler-service:2.0.1 --help
+docker run -p 8080:8080 ghga/reverse-transpiler-service:2.1.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/config_schema.json
+++ b/config_schema.json
@@ -47,6 +47,43 @@
       ],
       "title": "Mongo Timeout"
     },
+    "db_version_collection": {
+      "description": "The name of the collection containing DB version information for this service",
+      "examples": [
+        "ifrsDbVersions"
+      ],
+      "title": "Db Version Collection",
+      "type": "string"
+    },
+    "migration_wait_sec": {
+      "description": "The number of seconds to wait before checking the DB version again",
+      "examples": [
+        5,
+        30,
+        180
+      ],
+      "title": "Migration Wait Sec",
+      "type": "integer"
+    },
+    "migration_max_wait_sec": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The maximum number of seconds to wait for migrations to complete before raising an error.",
+      "examples": [
+        null,
+        300,
+        600,
+        3600
+      ],
+      "title": "Migration Max Wait Sec"
+    },
     "service_name": {
       "default": "rts",
       "description": "Short name of this service",
@@ -404,6 +441,8 @@
     "artifact_topic",
     "mongo_dsn",
     "db_name",
+    "db_version_collection",
+    "migration_wait_sec",
     "service_instance_id",
     "kafka_servers",
     "sheet_names"

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -7,6 +7,7 @@ cors_allowed_methods: null
 cors_allowed_origins: null
 cors_exposed_headers: null
 db_name: rts
+db_version_collection: rtsDbVersions
 docs_url: /docs
 generate_correlation_id: true
 host: 127.0.0.1
@@ -26,6 +27,8 @@ kafka_ssl_password: ''
 log_format: null
 log_level: INFO
 log_traceback: true
+migration_max_wait_sec: null
+migration_wait_sec: 10
 mongo_dsn: '**********'
 mongo_timeout: 300
 openapi_url: /openapi.json

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,7 +34,7 @@ info:
   description: A service running a REST API that serves accessioned metadata files
     by study ID
   title: Reverse Transpiler Service
-  version: 2.0.1
+  version: 2.1.0
 openapi: 3.1.0
 paths:
   /health:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "rts"
-version = "2.0.1"
+version = "2.1.0"
 description = "Reverse Transpiler Service - A service running a REST API that serves accessioned metadata files by study ID"
 dependencies = [
     "typer >= 0.19",

--- a/scripts/check_class_defs.py
+++ b/scripts/check_class_defs.py
@@ -19,10 +19,8 @@
 import inspect
 
 # Import the abstract base classes and their implementations
-from rts.adapters.outbound.dao import WorkbookDao  # noqa: F401
 from rts.core.rev_tran import ReverseTranspiler  # noqa: F401
 from rts.ports.inbound.rev_tran import ReverseTranspilerPort
-from rts.ports.outbound.dao import WorkbookDaoPort
 
 
 def print_links(abc_method: type, imp_method: type):
@@ -68,7 +66,7 @@ def check_implementation(abc_class: type):
 
 def main():
     """Test me"""
-    ports = [ReverseTranspilerPort, WorkbookDaoPort]
+    ports = [ReverseTranspilerPort]
     for port in ports:
         check_implementation(port)
 

--- a/scripts/update_config_docs.py
+++ b/scripts/update_config_docs.py
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generates a JSON schema from the service's Config class as well as a corresponding
-example config yaml (or check whether these files are up to date).
+"""Generate a JSON Schema from the service's Config class and an example
+config YAML file, or check whether the existing files are up to date.
 """
 
 import importlib
@@ -46,7 +46,7 @@ class ValidationError(RuntimeError):
 def get_config_class():
     """
     Dynamically imports and returns the Config class from the current service.
-    This makes the script service repo agnostic.
+    This makes the script agnostic to the service repository.
     """
     # get the name of the microservice package
     with subprocess.Popen(
@@ -82,28 +82,22 @@ def get_schema() -> str:
 
 def get_example() -> str:
     """Returns an example config YAML."""
-
     config = get_dev_config()
     normalized_config_dict = config.model_dump(mode="json", by_alias=True)
     return yaml.dump(normalized_config_dict, indent=2, sort_keys=True)
 
 
 def update_docs():
-    """Update the example config and config schema files documenting the config
-    options."""
-
-    example = get_example()
-    with open(EXAMPLE_CONFIG_YAML, "w", encoding="utf-8") as example_file:
-        example_file.write(example)
-
-    schema = get_schema()
-    with open(CONFIG_SCHEMA_JSON, "w", encoding="utf-8") as schema_file:
-        schema_file.write(schema)
+    """Update the example config YAML and JSON Schema files documenting the
+    config options.
+    """
+    EXAMPLE_CONFIG_YAML.write_text(get_example(), encoding="utf-8")
+    CONFIG_SCHEMA_JSON.write_text(get_schema(), encoding="utf-8")
 
 
 def print_diff(expected: str, observed: str):
-    """Print differences between expected and observed files."""
-    echo_failure("Differences in Config YAML:")
+    """Print differences between expected and observed example config YAML."""
+    echo_failure("Differences in config YAML file:")
     for line in unified_diff(
         expected.splitlines(keepends=True),
         observed.splitlines(keepends=True),
@@ -114,28 +108,25 @@ def print_diff(expected: str, observed: str):
 
 
 def check_docs():
-    """Check whether the example config and config schema files documenting the config
-    options are up to date.
+    """Check whether the example config YAML and JSON Schema files are up to date.
 
     Raises:
-        ValidationError: if not up to date.
+        ValidationError: If not up to date.
     """
 
     example_expected = get_example()
-    with open(EXAMPLE_CONFIG_YAML, encoding="utf-8") as example_file:
-        example_observed = example_file.read()
+    example_observed = EXAMPLE_CONFIG_YAML.read_text(encoding="utf-8")
     if example_expected != example_observed:
         print_diff(example_expected, example_observed)
         raise ValidationError(
-            f"Example config YAML at '{EXAMPLE_CONFIG_YAML}' is not up to date."
+            f"Example config YAML file at '{EXAMPLE_CONFIG_YAML}' is not up to date."
         )
 
     schema_expected = get_schema()
-    with open(CONFIG_SCHEMA_JSON, encoding="utf-8") as schema_file:
-        schema_observed = schema_file.read()
+    schema_observed = CONFIG_SCHEMA_JSON.read_text(encoding="utf-8")
     if schema_expected != schema_observed:
         raise ValidationError(
-            f"Config schema JSON at '{CONFIG_SCHEMA_JSON}' is not up to date."
+            f"Config schema JSON file at '{CONFIG_SCHEMA_JSON}' is not up to date."
         )
 
 

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -151,7 +151,7 @@ def read_design_description() -> str:
 
 
 def generate_config_docs() -> str:
-    """Generate markdown-formatted documentation for the configration parameters
+    """Generate markdown-formatted documentation for the configuration parameters
     listed in the config schema."""
 
     parser = jsonschema2md.Parser(
@@ -167,7 +167,7 @@ def generate_config_docs() -> str:
     properties_index = md_lines.index("## Properties\n\n")
     md_lines = md_lines[properties_index + 1 :]
 
-    return "\n".join(md_lines)
+    return "".join(md_lines).rstrip()
 
 
 def generate_openapi_docs() -> str:

--- a/src/rts/adapters/outbound/dao.py
+++ b/src/rts/adapters/outbound/dao.py
@@ -17,6 +17,7 @@
 
 import json
 import logging
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from io import BytesIO
 
@@ -34,15 +35,18 @@ from rts.ports.outbound.dao import (
 
 log = logging.getLogger(__name__)
 
-__all__ = ["METADATA_COLLECTION"]
-
-METADATA_COLLECTION = "metadata"
+__all__ = ["GridFSDaoFactory"]
 
 
 class GridFSDaoFactory(GridFSDaoFactoryPort):
+    """A factory that produces objects able to interact with GridFS"""
+
     @classmethod
     @asynccontextmanager
-    async def construct(cls, *, config: MongoDbConfig):
+    async def construct(
+        cls, *, config: MongoDbConfig
+    ) -> AsyncGenerator["GridFSDaoFactory"]:
+        """Instantiate a GridFSDaoFactory with a configured MongoDB client"""
         async with ConfiguredMongoClient(config=config) as client:
             db = client[config.db_name]
             grid_fs = AsyncGridFS(db)

--- a/src/rts/adapters/outbound/dao.py
+++ b/src/rts/adapters/outbound/dao.py
@@ -15,102 +15,74 @@
 
 """DAO implementation"""
 
+import json
 import logging
-from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from io import BytesIO
 
 from gridfs.asynchronous import AsyncGridFS
-from hexkit.protocols.dao import DaoFactoryProtocol
 from hexkit.providers.mongodb.provider import ConfiguredMongoClient, MongoDbConfig
 from openpyxl import Workbook
 
 from rts.models import StudyMetadata
-from rts.ports.outbound.dao import MetadataDao, ResourceNotFoundError, WorkbookDaoPort
+from rts.ports.outbound.dao import (
+    GridFSDao,
+    GridFSDaoFactoryPort,
+    MetadataGridFSDaoPort,
+    WorkbookGridFSDaoPort,
+)
 
 log = logging.getLogger(__name__)
 
-__all__ = [
-    "FILE_EXTENSION",
-    "METADATA_COLLECTION",
-    "WorkbookDao",
-    "get_metadata_dao",
-    "get_workbook_dao",
-]
+__all__ = ["METADATA_COLLECTION"]
 
 METADATA_COLLECTION = "metadata"
-FILE_EXTENSION = ".xlsx"
 
 
-async def get_metadata_dao(*, dao_factory: DaoFactoryProtocol) -> MetadataDao:
-    """Construct a metadata DAO from the provided dao_factory"""
-    return await dao_factory.get_dao(
-        name=METADATA_COLLECTION,
-        dto_model=StudyMetadata,
-        id_field="study_accession",
-    )
+class GridFSDaoFactory(GridFSDaoFactoryPort):
+    @classmethod
+    @asynccontextmanager
+    async def construct(cls, *, config: MongoDbConfig):
+        async with ConfiguredMongoClient(config=config) as client:
+            db = client[config.db_name]
+            grid_fs = AsyncGridFS(db)
+            yield GridFSDaoFactory(grid_fs=grid_fs)
 
-
-class WorkbookDao(WorkbookDaoPort):
-    """Limited DAO for storing workbook data in the database."""
-
-    def __init__(self, grid_fs: AsyncGridFS):
-        """DO NOT CALL DIRECTLY! Use `get_workbook_dao` instead.
-
-        Initialize the WorkbookDao with the provided AsyncGridFS instance.
-        """
+    def __init__(self, *, grid_fs: AsyncGridFS):
         self._grid_fs = grid_fs
 
-    async def upsert(self, *, workbook: Workbook, study_accession: str) -> None:
-        """Upsert the workbook for a given study accession.
+    def get_metadata_dao(self) -> MetadataGridFSDaoPort:
+        """Return a MetadataDaoPort instance"""
 
-        If the workbook already exists, it will be replaced.
-        """
-        # Convert the workbook to a bytestream
-        workbook_bytestream = BytesIO()
-        workbook.save(workbook_bytestream)
-        workbook_bytestream.seek(0)
+        def serialize(metadata: StudyMetadata) -> bytes:
+            return bytes(metadata.model_dump_json(), encoding="utf-8")
 
-        # Delete the file if it already exists
-        await self._grid_fs.delete(study_accession)
+        def deserialize(serialized_data: bytes) -> StudyMetadata:
+            return StudyMetadata(**json.loads(serialized_data.decode()))
 
-        # Insert new file
-        await self._grid_fs.put(
-            data=workbook_bytestream,
-            _id=study_accession,
-            filename=f"{study_accession}{FILE_EXTENSION}",  # e.g. my_accession.xlsx
+        return GridFSDao(
+            grid_fs=self._grid_fs,
+            prefix="metadata__",
+            file_extension="",
+            serialize_fn=serialize,
+            deserialize_fn=deserialize,
         )
-        log.debug("Workbook upserted for study accession: %s", study_accession)
 
-    async def find(self, *, study_accession: str) -> bytes:
-        """Retrieve the workbook for a given study accession.
+    def get_workbook_dao(self) -> WorkbookGridFSDaoPort:
+        """Return a WorkbookDaoPort instance"""
 
-        Raises `ResourceNotFoundError` if the workbook does not exist for the
-        given study accession.
-        """
-        result = await self._grid_fs.find_one(study_accession)
+        def serialize(workbook: Workbook) -> bytes:
+            """Convert the workbook to bytes"""
+            workbook_bytestream = BytesIO()
+            workbook.save(workbook_bytestream)
+            workbook_bytestream.seek(0)
+            return workbook_bytestream.read()
 
-        if result is None:
-            raise ResourceNotFoundError(id_=study_accession)
-
-        log.debug("Workbook found for study accession: %s", study_accession)
-
-        return await result.read()
-
-    async def delete(self, *, study_accession: str) -> None:
-        """Delete the workbook for a given study accession.
-
-        Does not raise an error if the workbook does not exist, as GridFS doesn't raise
-        an error when trying to delete a non-existent file.
-        """
-        await self._grid_fs.delete(study_accession)
-        log.debug("Workbook deleted for study accession: %s", study_accession)
-
-
-@asynccontextmanager
-async def get_workbook_dao(*, config: MongoDbConfig) -> AsyncGenerator[WorkbookDaoPort]:
-    """Constructs the WorkbookDao with the provided MongoDB configuration."""
-    async with ConfiguredMongoClient(config=config) as client:
-        db = client[config.db_name]
-        grid_fs = AsyncGridFS(db)
-        yield WorkbookDao(grid_fs=grid_fs)
+        # Workbook data is returned as bytes - use default deserializer (return as-is)
+        return GridFSDao(
+            grid_fs=self._grid_fs,
+            prefix="workbook__",
+            file_extension=".xlsx",
+            serialize_fn=serialize,
+            deserialize_fn=lambda data: data,
+        )

--- a/src/rts/adapters/outbound/dao.py
+++ b/src/rts/adapters/outbound/dao.py
@@ -59,7 +59,7 @@ class GridFSDaoFactory(GridFSDaoFactoryPort):
         """Return a MetadataDaoPort instance"""
 
         def serialize(metadata: StudyMetadata) -> bytes:
-            return bytes(metadata.model_dump_json(), encoding="utf-8")
+            return metadata.model_dump_json().encode()
 
         def deserialize(serialized_data: bytes) -> StudyMetadata:
             return StudyMetadata(**json.loads(serialized_data.decode()))

--- a/src/rts/cli.py
+++ b/src/rts/cli.py
@@ -19,7 +19,7 @@ import asyncio
 
 import typer
 
-from rts.main import consume_events, run_rest_app
+from rts.main import consume_events, migrate_db, run_rest_app
 
 cli = typer.Typer()
 
@@ -34,3 +34,9 @@ def sync_run_api():
 def sync_consume_events(run_forever: bool = True):
     """Run an event consumer listening to the specified topic."""
     asyncio.run(consume_events(run_forever=run_forever))
+
+
+@cli.command(name="migrate-db")
+def sync_migrate_db():
+    """Run database migrations."""
+    asyncio.run(migrate_db())

--- a/src/rts/config.py
+++ b/src/rts/config.py
@@ -19,7 +19,7 @@ from ghga_service_commons.api import ApiConfigBase
 from hexkit.config import config_from_yaml
 from hexkit.log import LoggingConfig
 from hexkit.providers.akafka import KafkaConfig
-from hexkit.providers.mongodb import MongoDbConfig
+from hexkit.providers.mongodb.migrations import MigrationConfig
 from pydantic import Field
 
 from rts.adapters.inbound.event_sub import EventSubTranslatorConfig
@@ -36,7 +36,7 @@ class Config(
     ApiConfigBase,
     LoggingConfig,
     KafkaConfig,
-    MongoDbConfig,
+    MigrationConfig,
     EventSubTranslatorConfig,
 ):
     """Config parameters and their defaults."""

--- a/src/rts/core/rev_tran.py
+++ b/src/rts/core/rev_tran.py
@@ -82,7 +82,7 @@ class ReverseTranspiler(ReverseTranspilerPort):
         """
         accession = study_metadata.study_accession
         try:
-            existing_metadata = await self._metadata_dao.find(id_=accession)
+            existing_metadata = await self._metadata_dao.find(filename=accession)
             log.debug(
                 "Metadata for accession '%s' already exists, comparing...",
                 accession,
@@ -104,13 +104,13 @@ class ReverseTranspiler(ReverseTranspilerPort):
                 accession,
             )
 
-        await self._metadata_dao.upsert(data=study_metadata, id_=accession)
+        await self._metadata_dao.upsert(data=study_metadata, filename=accession)
 
         log.debug("Transpiling metadata to workbook for accession '%s'.", accession)
         workbook = self._reverse_transpile(study_metadata)
 
         log.debug("Workbook created for accession '%s', upserting to DB.", accession)
-        await self._workbook_dao.upsert(data=workbook, id_=accession)
+        await self._workbook_dao.upsert(data=workbook, filename=accession)
         log.debug("Workbook upserted for study accession: %s", accession)
 
     async def retrieve_metadata(self, *, study_accession: str) -> StudyMetadata:
@@ -120,7 +120,7 @@ class ReverseTranspiler(ReverseTranspilerPort):
         given study accession.
         """
         try:
-            metadata = await self._metadata_dao.find(id_=study_accession)
+            metadata = await self._metadata_dao.find(filename=study_accession)
             return metadata
         except ResourceNotFoundError as err:
             error = self.MetadataNotFoundError(study_accession=study_accession)
@@ -136,11 +136,11 @@ class ReverseTranspiler(ReverseTranspilerPort):
         Does not raise an error if the metadata or workbook does not exist.
         """
         try:
-            await self._metadata_dao.delete(id_=study_accession)
+            await self._metadata_dao.delete(filename=study_accession)
         except ResourceNotFoundError:
             log.debug("Metadata for accession '%s' already deleted.", study_accession)
 
-        await self._workbook_dao.delete(id_=study_accession)
+        await self._workbook_dao.delete(filename=study_accession)
         log.info("Workbook and metadata deleted for accession '%s'.", study_accession)
 
     async def retrieve_workbook(self, *, study_accession: str) -> bytes:
@@ -152,7 +152,7 @@ class ReverseTranspiler(ReverseTranspilerPort):
         - The workbook as bytes.
         """
         try:
-            workbook_data = await self._workbook_dao.find(id_=study_accession)
+            workbook_data = await self._workbook_dao.find(filename=study_accession)
             log.debug("Workbook found for study accession: %s", study_accession)
             return workbook_data
         except ResourceNotFoundError as err:

--- a/src/rts/inject.py
+++ b/src/rts/inject.py
@@ -29,11 +29,7 @@ from rts.config import Config
 from rts.core.rev_tran import ReverseTranspiler
 from rts.ports.inbound.rev_tran import ReverseTranspilerPort
 
-__all__ = [
-    "prepare_core",
-    "prepare_event_subscriber",
-    "prepare_rest_app",
-]
+__all__ = ["prepare_core", "prepare_event_subscriber", "prepare_rest_app"]
 
 
 @asynccontextmanager

--- a/src/rts/main.py
+++ b/src/rts/main.py
@@ -25,6 +25,9 @@ from hexkit.log import configure_logging
 
 from rts.config import Config
 from rts.inject import prepare_event_subscriber, prepare_rest_app
+from rts.migrations.entry import run_db_migrations
+
+DB_VERSION = 2
 
 
 async def run_rest_app():
@@ -43,3 +46,10 @@ async def consume_events(run_forever: bool = True):
 
     async with prepare_event_subscriber(config=config) as event_subscriber:
         await event_subscriber.run(forever=run_forever)
+
+
+async def migrate_db() -> None:
+    """Run database migrations as a one-off command."""
+    config = Config()  # type: ignore
+    configure_logging(config=config)
+    await run_db_migrations(config=config, target_version=DB_VERSION)

--- a/src/rts/migrations/__init__.py
+++ b/src/rts/migrations/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DB migration logic"""
+
+from .definitions import V2Migration
+from .entry import run_db_migrations
+
+__all__ = ["V2Migration", "run_db_migrations"]

--- a/src/rts/migrations/definitions.py
+++ b/src/rts/migrations/definitions.py
@@ -1,0 +1,70 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Database migration logic for the WPS."""
+
+from contextlib import suppress
+
+from hexkit.providers.mongodb.migrations import MigrationDefinition, Reversible
+
+from rts.adapters.outbound.dao import GridFSDaoFactory
+from rts.config import Config
+from rts.models import StudyMetadata
+from rts.ports.outbound.dao import ResourceNotFoundError
+
+METADATA = "metadata"
+
+
+class V2Migration(MigrationDefinition, Reversible):
+    """Move the contents of the study metadata collection ("metadata") into GridFS.
+
+    This can be reversed by removing the data from GridFS and storing it back into a
+    collection with the original name ("metadata").
+    """
+
+    version = 2
+
+    async def apply(self):
+        """Perform the migration."""
+        # Iterate over the collection and move each item into GridFS
+        collection = self._db[METADATA]
+        config = Config()
+        async with GridFSDaoFactory.construct(config=config) as gridfs_dao_factory:
+            gridfs_dao = gridfs_dao_factory.get_metadata_dao()
+            async for doc in collection.find():
+                doc["study_accession"] = doc.pop("_id")
+                metadata = StudyMetadata(**doc)
+                accession = metadata.study_accession
+                # We don't want to accidentally overwrite something in this process,
+                #  so be careful and double check there's no name collision:
+                with suppress(ResourceNotFoundError):
+                    existing = await gridfs_dao.find(id_=accession)
+                    if existing:
+                        raise RuntimeError(f"Unexpected name collision for {accession}")
+                await gridfs_dao.upsert(data=metadata, id_=accession)
+
+        await collection.drop()
+
+    async def unapply(self):
+        """Reverse the migration"""
+        collection = self._db[METADATA]
+        config = Config()
+        async with GridFSDaoFactory.construct(config=config) as gridfs_dao_factory:
+            gridfs_dao = gridfs_dao_factory.get_metadata_dao()
+            async for metadata in gridfs_dao.find_all():
+                doc = metadata.model_dump()
+                doc["_id"] = doc.pop("study_accession")
+                await collection.insert_one(doc)
+                await gridfs_dao.delete(id_=doc["_id"])

--- a/src/rts/migrations/entry.py
+++ b/src/rts/migrations/entry.py
@@ -1,0 +1,49 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing controller function for DB migrations"""
+
+from hexkit.providers.mongodb.migrations import (
+    MigrationConfig,
+    MigrationManager,
+    MigrationMap,
+)
+
+from rts.migrations.definitions import V2Migration
+
+MIGRATION_MAP = {2: V2Migration}
+
+
+async def run_db_migrations(
+    *,
+    config: MigrationConfig,
+    target_version: int,
+    migration_map: MigrationMap | None = None,
+):
+    """Run all migrations.
+    Args
+    - `config`: Config containing mongo_dsn string and DB versioning collection name
+    - `target_version`: Which version the db needs to be at for this version of the service
+    - `migration_map`: Mapping of version to migration definition. Defaults to `MIGRATION_MAP`.
+    `migration_map` can be specified for testing, but may be left unspecified for production.
+    """
+    migration_map = migration_map or MIGRATION_MAP
+
+    async with MigrationManager(
+        config=config,
+        target_version=target_version,
+        migration_map=MIGRATION_MAP,
+    ) as mm:
+        await mm.migrate_or_wait()

--- a/src/rts/ports/outbound/dao.py
+++ b/src/rts/ports/outbound/dao.py
@@ -16,7 +16,7 @@
 """DAO Port definition"""
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 from gridfs import AsyncGridFS
@@ -107,6 +107,14 @@ class GridFSDao[InputType: Any, OutputType: Any]:
         serialized_data = await gridfs_file_object.read()
         deserialized_data = self._deserialize_fn(serialized_data)
         return deserialized_data
+
+    async def find_all(self) -> AsyncIterator[OutputType]:
+        """Returns an iterator of all files beginning with this DAO's assigned prefix"""
+        filenames = [
+            f for f in (await self._grid_fs.list()) if f.startswith(self._prefix)
+        ]
+        for filename in filenames:
+            yield await self._grid_fs.get(filename)
 
     async def delete(self, *, id_: str) -> None:
         """Delete the file for a given identifier (do not include the prefix).

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -25,11 +25,9 @@ from hexkit.providers.akafka import KafkaEventSubscriber
 from hexkit.providers.akafka.testutils import KafkaFixture
 from hexkit.providers.mongodb.testutils import MongoDbFixture
 
-from rts.adapters.outbound.dao import get_metadata_dao
 from rts.config import Config
 from rts.inject import prepare_core, prepare_event_subscriber, prepare_rest_app
 from rts.ports.inbound.rev_tran import ReverseTranspilerPort
-from rts.ports.outbound.dao import MetadataDao
 from tests.fixtures.config import get_config
 
 
@@ -42,7 +40,6 @@ class JointFixture:
     event_subscriber: KafkaEventSubscriber
     kafka: KafkaFixture
     mongodb: MongoDbFixture
-    metadata_dao: MetadataDao
     rest_client: AsyncTestClient
 
 
@@ -74,6 +71,5 @@ async def joint_fixture(
             event_subscriber=event_subscriber,
             kafka=kafka,
             mongodb=mongodb,
-            metadata_dao=await get_metadata_dao(dao_factory=mongodb.dao_factory),
             rest_client=rest_client,
         )

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -3,6 +3,8 @@ kafka_servers: ["kafka:9092"]
 mongo_dsn: mongodb://localhost:27017
 db_name: rts
 mongo_timeout: 300
+db_version_collection: rtsDbVersions
+migration_wait_sec: 10
 artifact_topic: artifacts
 sheet_names:
   analyses: Analysis

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -2,7 +2,7 @@ service_instance_id: "1"
 kafka_servers: ["kafka:9092"]
 mongo_dsn: mongodb://localhost:27017
 db_name: rts
-mongo_timeout: 300
+mongo_timeout: 10
 db_version_collection: rtsDbVersions
 migration_wait_sec: 10
 artifact_topic: artifacts

--- a/tests/integration/test_gridfs_dao.py
+++ b/tests/integration/test_gridfs_dao.py
@@ -1,0 +1,152 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the GridFSDao class"""
+
+from io import BytesIO
+from unittest.mock import Mock
+
+import pytest
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+
+from rts.adapters.outbound.dao import GridFSDaoFactory
+from rts.models import StudyMetadata
+from rts.ports.outbound.dao import GridFSDao, ResourceNotFoundError
+from tests.fixtures.config import get_config
+
+pytestmark = pytest.mark.asyncio()
+
+
+def fake_save_factory(return_value: str):
+    """Return a function that writes the value to a provided bytestream"""
+
+    def fake_save(bytestream: BytesIO):
+        """Used for mocking the `Workbook.save()` method"""
+        bytestream.write(return_value.encode("utf-8"))
+
+    return fake_save
+
+
+async def test_absent_file(mongodb: MongoDbFixture):
+    """Test deleting and finding files that don't exist."""
+    config = get_config(sources=[mongodb.config])
+    async with GridFSDaoFactory.construct(config=config) as gridfs_dao_factory:
+        metadata_dao = gridfs_dao_factory.get_metadata_dao()
+
+        with pytest.raises(ResourceNotFoundError):
+            await metadata_dao.delete(filename="myfile")
+        with pytest.raises(ResourceNotFoundError):
+            await metadata_dao.find(filename="myfile")
+
+        workbook_dao = gridfs_dao_factory.get_workbook_dao()
+        with pytest.raises(ResourceNotFoundError):
+            await workbook_dao.delete(filename="myfile")
+        with pytest.raises(ResourceNotFoundError):
+            await workbook_dao.find(filename="myfile")
+
+
+async def test_proper_delete(mongodb: MongoDbFixture):
+    """Test deleting files that do exist."""
+    config = get_config(sources=[mongodb.config])
+    async with GridFSDaoFactory.construct(config=config) as gridfs_dao_factory:
+        metadata_dao = gridfs_dao_factory.get_metadata_dao()
+
+        study_metadata = StudyMetadata(
+            study_accession="test1", content={"some": "data"}
+        )
+        await metadata_dao.upsert(data=study_metadata, filename="myfile")
+
+        check_metadata = await metadata_dao.find(filename="myfile")
+        assert check_metadata.model_dump() == study_metadata.model_dump()
+
+        await metadata_dao.delete(filename="myfile")
+        with pytest.raises(ResourceNotFoundError):
+            await metadata_dao.find(filename="myfile")
+
+        # Test the workbook dao:
+        workbook_dao = gridfs_dao_factory.get_workbook_dao()
+        mock_workbook = Mock()
+        mock_workbook.save = fake_save_factory("some data!")
+
+        await workbook_dao.upsert(data=mock_workbook, filename="myfile")
+        check_workbook = await workbook_dao.find(filename="myfile")
+        assert check_workbook == b"some data!"
+
+        await workbook_dao.delete(filename="myfile")
+        with pytest.raises(ResourceNotFoundError):
+            await workbook_dao.find(filename="myfile")
+
+
+async def test_upsert(mongodb: MongoDbFixture):
+    """Test upsertion with and without existing files"""
+    config = get_config(sources=[mongodb.config])
+    async with GridFSDaoFactory.construct(config=config) as gridfs_dao_factory:
+        metadata_dao = gridfs_dao_factory.get_metadata_dao()
+        study_metadata = StudyMetadata(
+            study_accession="test1", content={"some": "data"}
+        )
+        await metadata_dao.upsert(data=study_metadata, filename="myfile")
+
+        study_metadata2 = study_metadata.model_copy(update={"study_accession": "test2"})
+        await metadata_dao.upsert(data=study_metadata2, filename="myfile")
+        check_metadata = await metadata_dao.find(filename="myfile")
+        assert check_metadata.study_accession == "test2"
+
+        # Test the workbook dao:
+        workbook_dao = gridfs_dao_factory.get_workbook_dao()
+        mock_workbook = Mock()
+        mock_workbook.save = fake_save_factory("some data!")
+
+        await workbook_dao.upsert(data=mock_workbook, filename="myfile")
+
+        mock_workbook.save = fake_save_factory("some other data!")
+        await workbook_dao.upsert(data=mock_workbook, filename="myfile")
+        check_workbook = await workbook_dao.find(filename="myfile")
+        assert check_workbook == b"some other data!"
+
+
+async def test_serializer_error(mongodb: MongoDbFixture):
+    """Test errors that occur during serialization"""
+    config = get_config(sources=[mongodb.config])
+    async with GridFSDaoFactory.construct(config=config) as gridfs_dao_factory:
+        metadata_dao = gridfs_dao_factory.get_metadata_dao()
+        metadata = Mock()
+        metadata.model_dump_json.side_effect = RuntimeError()
+        with pytest.raises(GridFSDao.SerializationError):
+            await metadata_dao.upsert(data=metadata, filename="myfile")
+
+        # Test the workbook dao:
+        workbook_dao = gridfs_dao_factory.get_workbook_dao()
+        mock_workbook = Mock()
+        mock_workbook.save.side_effect = RuntimeError()
+        with pytest.raises(GridFSDao.SerializationError):
+            await workbook_dao.upsert(data=mock_workbook, filename="myfile")
+
+
+async def test_deserializer_error(mongodb: MongoDbFixture):
+    """Test errors that occur during deserialization.
+
+    We only test the metadata DAO here because the workbook DAO is stored in bytes,
+    returned in bytes, and thus should always work.
+    """
+    config = get_config(sources=[mongodb.config])
+    async with GridFSDaoFactory.construct(config=config) as gridfs_dao_factory:
+        metadata_dao = gridfs_dao_factory.get_metadata_dao()
+        metadata = Mock()
+        metadata.model_dump_json.return_value = "Gibberish you can save but not get"
+        await metadata_dao.upsert(data=metadata, filename="myfile")
+
+        with pytest.raises(GridFSDao.DeserializationError):
+            _ = await metadata_dao.find(filename="myfile")

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1,0 +1,129 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DB migrations"""
+
+from io import BytesIO
+from unittest.mock import AsyncMock
+
+import pytest
+from gridfs import GridFS
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+from openpyxl import Workbook
+
+from rts.adapters.outbound.dao import GridFSDaoFactory
+from rts.core.rev_tran import ReverseTranspiler
+from rts.migrations.entry import run_db_migrations
+from rts.models import StudyMetadata
+from tests.fixtures.config import get_config
+
+pytestmark = pytest.mark.asyncio()
+
+METADATA = "metadata"
+
+
+async def store_workbook_old_code(grid_fs: GridFS, workbook: Workbook, accession: str):
+    """Store a workbook in grid fs using the old code before the v2 changes"""
+    # Convert the workbook to a bytestream
+    workbook_bytestream = BytesIO()
+    workbook.save(workbook_bytestream)
+    workbook_bytestream.seek(0)
+
+    # Insert new file
+    grid_fs.put(data=workbook_bytestream, _id=accession, filename=f"{accession}.xlsx")
+
+
+async def test_v2_migration(mongodb: MongoDbFixture):
+    """Test the v2 migration.
+
+    Insert some StudyMetadata documents into the metadata collection, run the migration,
+    verify the data is in GridFS and the collection is dropped. Then reverse the
+    migration and verify things are back where they started.
+    """
+    config = get_config(sources=[mongodb.config])
+    db = mongodb.client.get_database(config.db_name)
+    sync_grid_fs = GridFS(db)
+    collection = db[METADATA]
+
+    reverse_transpiler = ReverseTranspiler(
+        config=config, metadata_dao=AsyncMock(), workbook_dao=AsyncMock()
+    )
+
+    # Load workbook data
+    with open("tests/fixtures/test_artifact.json") as file:
+        study_metadata_json = file.read()
+
+    study_metadata = StudyMetadata.model_validate_json(study_metadata_json)
+    metadata_docs = []
+    workbooks = []
+
+    # Make multiple copies of that data just with a new accession each time
+    for i in range(5):
+        accession = f"test{i}"
+        metadata = study_metadata.model_copy(update={"study_accession": accession})
+        doc = metadata.model_dump()
+        doc["_id"] = doc.pop("study_accession")
+        metadata_docs.append(doc)
+        workbook = reverse_transpiler._reverse_transpile(study_metadata)
+        workbooks.append(workbook)
+        await store_workbook_old_code(
+            grid_fs=sync_grid_fs, workbook=workbook, accession=accession
+        )
+
+    # Insert the documents for the study metadata accompanying the workbook files
+    collection.insert_many(metadata_docs)
+
+    # Run the migration
+    await run_db_migrations(config=config, target_version=2)
+
+    # Check that the metadata collection got dropped
+    assert METADATA not in db.list_collection_names()
+
+    # Check that the existing workbook files got prefixed with 'workbook__'
+    filenames = [x for x in sync_grid_fs.list() if not x.startswith("metadata__")]
+    assert all(x.startswith("workbook__") for x in filenames)
+
+    # Make sure the DAOs pull back the expected data
+    async with GridFSDaoFactory.construct(config=config) as grid_fs_factory:
+        metadata_dao = grid_fs_factory.get_metadata_dao()
+        metadata_files = [x async for x in metadata_dao.find_all()]
+        assert len(metadata_files) == len(metadata_docs)
+
+        workbook_dao = grid_fs_factory.get_workbook_dao()
+        workbook_files = [x async for x in workbook_dao.find_all()]
+        assert len(workbook_files) == len(workbooks)
+
+    # Reverse the migration
+    await run_db_migrations(config=config, target_version=1)
+
+    async with GridFSDaoFactory.construct(config=config) as grid_fs_factory:
+        metadata_dao = grid_fs_factory.get_metadata_dao()
+        metadata_files = [x async for x in metadata_dao.find_all()]
+        assert len(metadata_files) == 0
+
+        # Verify that there are still workbooks, but the prefix is removed
+        workbook_dao = grid_fs_factory.get_workbook_dao()
+        workbook_files = [x async for x in workbook_dao.find_all()]
+        assert len(workbook_files) == 0  # DAO sees nothing with the expected prefix
+
+        # List the remaining files in grid fs and make sure none have the prefix
+        assert all(
+            not filename.startswith("workbook__") for filename in sync_grid_fs.list()
+        )
+
+    # Refresh the metadata collection and verify the docs exist there again
+    collection = db[METADATA]
+    metadata_retrieved = collection.find().sort("_id").to_list()
+    assert metadata_retrieved == metadata_docs

--- a/tests/integration/test_rev_tran.py
+++ b/tests/integration/test_rev_tran.py
@@ -129,7 +129,7 @@ async def test_upsert(joint_fixture: JointFixture):
     accession = study_metadata.study_accession
 
     # Delete the workbook from storage, since that is only created when new data comes in
-    await reverse_transpiler._workbook_dao.delete(study_accession=accession)  # type: ignore
+    await reverse_transpiler._workbook_dao.delete(id_=accession)  # type: ignore
 
     # Load the data again, but this time it shouldn't recreate the workbook
     await reverse_transpiler.upsert_metadata(study_metadata=study_metadata)


### PR DESCRIPTION
Bumps the version to `2.1.0`

This PR updates the RTS so study metadata is stored in GridFS instead of a normal MongoDB collection. The reason behind this is that while we have taken steps to minimize the size of inbound metadata, there will inevitably be some instances where the 16MB limit is surpassed. Storing all the metadata in GridFS (which has no such limit) mitigates this problem before it crops up.

In this PR, we drop the normal hexkit DAO in favor of a new `GridFSDao`. It does not implement the full DAO specification because that is not needed here and would extend development time unnecessarily. This is currently the only service where we use GridFS (I think).

Since there are two kinds of data that we store in GridFS, the GridFSDao is generic over an input type and an output type. This lets us specify SerDe functions so retrieving workbook or StudyMetadata content behaves predictably. In MongoDB collections, everything is nicely partitioned by the collection structure, so we use the `AsyncGridFSBucket` API to achieve similar compartmentalization.

Finally, I added a migration that all existing workbook data from the default bucket to a `workbooks` bucket, and moves existing study metadata into a `metadata` bucket before dropping the metadata collection. This is reversible. 